### PR TITLE
fix Signature error

### DIFF
--- a/Sources/AliSMS/aliSinger.swift
+++ b/Sources/AliSMS/aliSinger.swift
@@ -15,10 +15,7 @@ import CryptoKit
 
 struct SHAHAMC1Singer: AliSign {
     
-    func sign(_ content: String, key: String) throws -> String {
-//        let msg = Array(content.utf8)
-//        let result = try HMAC(key: key, variant: .sha1).authenticate(msg)
-//        return result.base64
+    func sign(_ content: String, key: String) -> String {
         return encodeWithHMAC(content: content, key: key)
     }
     


### PR DESCRIPTION
签名也要做特殊URL编码，否则会造成前面中的=和url参数的=冲突导致发送失败。例如签名的结果是zJDF+Lrzhj/ThnlvIToysFRq6t4=，会造成请求的链接变为以下错误

```
http://dysmsapi.aliyuncs.com/?Signature=zJDF+Lrzhj/ThnlvIToysFRq6t4=&AccessKeyId=
```